### PR TITLE
[Convention]: refactor invalidate logic

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,17 @@
+name: Verify
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.18.0
+      - run: pnpm install
+      - run: pnpm verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22.18.0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm run verify

--- a/.prettier.json
+++ b/.prettier.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Please run `pnpm verify` before commit
+~~Please run `pnpm verify` before commit~~

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Please run `pnpm verify` before commit

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "verify": "prettier --check ./src"
+    "verify": "prettier --check ./src",
+    "prepare": "husky"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
@@ -17,6 +18,7 @@
     "@tanstack/react-query": "5.84.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "husky": "9.1.7",
     "lucide-react": "0.536.0",
     "radix-ui": "1.4.2",
     "react": "19.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/react-dom": "19.1.7",
     "@vitejs/plugin-react": "4.7.0",
     "eslint": "9.32.0",
+    "prettier": "3.6.2",
     "tailwindcss": "4.1.11",
     "typescript": "5.9.2",
     "vite": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/react-dom": "19.1.7",
     "@vitejs/plugin-react": "4.7.0",
     "eslint": "9.32.0",
-    "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
     "typescript": "5.9.2",
     "vite": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "verify": "prettier --check ./src"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
       lucide-react:
         specifier: 0.536.0
         version: 0.536.0(react@19.1.1)
@@ -1573,6 +1576,11 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3496,6 +3504,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       eslint:
         specifier: 9.32.0
         version: 9.32.0(jiti@2.5.1)
+      prettier:
+        specifier: 3.6.2
+        version: 3.6.2
       tailwindcss:
         specifier: 4.1.11
         version: 4.1.11
@@ -1781,6 +1784,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3652,6 +3660,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.6.2: {}
 
   punycode@2.3.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       eslint:
         specifier: 9.32.0
         version: 9.32.0(jiti@2.5.1)
-      postcss:
-        specifier: 8.5.6
-        version: 8.5.6
       tailwindcss:
         specifier: 4.1.11
         version: 4.1.11

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient({
   mutationCache: new MutationCache({
     onSuccess: (_, __, ___, mutation) => {
       if (mutation.meta?.inaroInvalidateKon) {
-        queryClient.invalidateQueries(mutation.meta.inaroInvalidateKon);
+        queryClient.invalidateQueries(mutation.meta.inaroInvalidateKon)
       }
     },
   }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
 import { Board } from "./components/Board";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 
 const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onSuccess: (_, __, ___, mutation) => {
+      if (mutation.meta?.inaroInvalidateKon) {
+        queryClient.invalidateQueries(mutation.meta.inaroInvalidateKon);
+      }
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient({
   mutationCache: new MutationCache({
     onSuccess: (_, __, ___, mutation) => {
       if (mutation.meta?.inaroInvalidateKon) {
-        queryClient.invalidateQueries(mutation.meta.inaroInvalidateKon)
+        queryClient.invalidateQueries(mutation.meta.inaroInvalidateKon);
       }
     },
   }),

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -37,7 +37,7 @@ export function Board() {
       activationConstraint: {
         distance: 8,
       },
-    })
+    }),
   );
 
   if (isLoading) {
@@ -74,13 +74,16 @@ export function Board() {
 
   const { columns, tasks } = boardData;
 
-  const tasksByColumn = tasks.reduce((acc, task) => {
-    if (!acc[task.column_id]) {
-      acc[task.column_id] = [];
-    }
-    acc[task.column_id].push(task);
-    return acc;
-  }, {} as Record<string, Task[]>);
+  const tasksByColumn = tasks.reduce(
+    (acc, task) => {
+      if (!acc[task.column_id]) {
+        acc[task.column_id] = [];
+      }
+      acc[task.column_id].push(task);
+      return acc;
+    },
+    {} as Record<string, Task[]>,
+  );
 
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event;
@@ -109,7 +112,7 @@ export function Board() {
 
       if (oldTaskColumnId === newTaskColumnId) {
         const columnTasks = tasks.filter(
-          (task) => task.column_id === oldTaskColumnId
+          (task) => task.column_id === oldTaskColumnId,
         );
         const oldIndex = columnTasks.findIndex((task) => task.id === activeId);
         const newIndex = columnTasks.findIndex((task) => task.id === overId);
@@ -198,7 +201,7 @@ export function Board() {
             <DragOverlay>
               {activeTask ? <TaskCard task={activeTask} isOverlay /> : null}
             </DragOverlay>,
-            document.body
+            document.body,
           )}
         </DndContext>
       </div>

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -98,7 +98,7 @@ export function Column({ column, tasks }: ColumnProps) {
                   task={task}
                   onUpdate={(params) => {
                     const currentTask = tasks.find(
-                      (t) => t.id === params.taskId
+                      (t) => t.id === params.taskId,
                     );
                     if (currentTask) {
                       updateTaskMutation.mutate({

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -29,8 +29,8 @@ export function Column({ column, tasks }: ColumnProps) {
   const { setNodeRef } = useDroppable({ id: column.id });
   const createTaskMutation = useCreateTask();
   const updateTaskMutation = useUpdateTask();
-  const deleteTaskMutation = useDeleteTask()
-  const deleteColumnMutation = useDeleteColumn()
+  const deleteTaskMutation = useDeleteTask();
+  const deleteColumnMutation = useDeleteColumn();
 
   const handleTitleSave = () => {
     if (title.trim()) {

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -27,10 +27,10 @@ export function Column({ column, tasks }: ColumnProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(column.title);
   const { setNodeRef } = useDroppable({ id: column.id });
-  const createTaskMutation = useCreateTask()
-  const updateTaskMutation = useUpdateTask()
-  const deleteTaskMutation = useDeleteTask()
-  const deleteColumnMutation = useDeleteColumn()
+  const createTaskMutation = useCreateTask();
+  const updateTaskMutation = useUpdateTask();
+  const deleteTaskMutation = useDeleteTask();
+  const deleteColumnMutation = useDeleteColumn();
 
   const handleTitleSave = () => {
     if (title.trim()) {

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -29,8 +29,8 @@ export function Column({ column, tasks }: ColumnProps) {
   const { setNodeRef } = useDroppable({ id: column.id });
   const createTaskMutation = useCreateTask();
   const updateTaskMutation = useUpdateTask();
-  const deleteTaskMutation = useDeleteTask();
-  const deleteColumnMutation = useDeleteColumn();
+  const deleteTaskMutation = useDeleteTask()
+  const deleteColumnMutation = useDeleteColumn()
 
   const handleTitleSave = () => {
     if (title.trim()) {

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -27,10 +27,10 @@ export function Column({ column, tasks }: ColumnProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(column.title);
   const { setNodeRef } = useDroppable({ id: column.id });
-  const createTaskMutation = useCreateTask();
-  const updateTaskMutation = useUpdateTask();
-  const deleteTaskMutation = useDeleteTask();
-  const deleteColumnMutation = useDeleteColumn();
+  const createTaskMutation = useCreateTask()
+  const updateTaskMutation = useUpdateTask()
+  const deleteTaskMutation = useDeleteTask()
+  const deleteColumnMutation = useDeleteColumn()
 
   const handleTitleSave = () => {
     if (title.trim()) {

--- a/src/components/NewColumn.tsx
+++ b/src/components/NewColumn.tsx
@@ -11,6 +11,8 @@ export const NewColumn = () => {
 
   const createColumn = () => {
     if (title.trim()) {
+
+
       const newColumnId = `col-${Date.now()}`;
       createColumnMutation.mutate({ id: newColumnId, title: title.trim() });
       setTitle("");

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -56,7 +56,7 @@ class ApiClient {
     id: string,
     title: string,
     description: string,
-    columnId: string
+    columnId: string,
   ) {
     return this.client.post<Task>("/tasks", {
       id,

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -7,7 +7,7 @@ export class HttpClient {
 
   private async request<T>(
     endpoint: string,
-    options: Omit<RequestInit, "body"> & { body?: unknown } = {}
+    options: Omit<RequestInit, "body"> & { body?: unknown } = {},
   ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     const body = options.body ? JSON.stringify(options.body) : undefined;

--- a/src/lib/useBoard.ts
+++ b/src/lib/useBoard.ts
@@ -15,14 +15,11 @@ export function useBoard() {
 }
 
 export function useCreateColumn() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: ({ id, title }: { id: string; title: string }) =>
       apiClient.createColumn(id, title),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: boardKeys.all });
-      queryClient.invalidateQueries({ queryKey: boardKeys.columns() });
+    meta: {
+      inaroInvalidateKon: [boardKeys.all, boardKeys.columns()],
     },
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,5 +7,5 @@ import { App } from "./App.tsx";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -17,7 +17,7 @@ const badgeVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
+  },
 );
 
 export interface BadgeProps

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -27,7 +27,7 @@ const variants = cva(
       variant: "default",
       size: "default",
     },
-  }
+  },
 );
 
 export interface ButtonProps

--- a/src/ui/Card.tsx
+++ b/src/ui/Card.tsx
@@ -7,7 +7,7 @@ export function Card({ className, ...props }: CardProps) {
     <div
       className={cn(
         "rounded-lg border border-gray-200 bg-white text-gray-900 shadow-sm",
-        className
+        className,
       )}
       {...props}
     />
@@ -38,7 +38,7 @@ export function CardTitle({
     <h3
       className={cn(
         "text-2xl font-semibold leading-none tracking-tight",
-        className
+        className,
       )}
       {...props}
     />

--- a/src/ui/IconButton.tsx
+++ b/src/ui/IconButton.tsx
@@ -20,7 +20,7 @@ const iconButtonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
+  },
 );
 
 export interface IconButtonProps

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -8,7 +8,7 @@ const variants = cva(
         true: "border-red-500",
       },
     },
-  }
+  },
 );
 export interface InputProps
   extends React.ComponentProps<"input">,

--- a/src/ui/Textarea.tsx
+++ b/src/ui/Textarea.tsx
@@ -15,7 +15,7 @@ const variants = cva(
     defaultVariants: {
       size: "default",
     },
-  }
+  },
 );
 
 export interface TextareaProps


### PR DESCRIPTION
This pull request includes updates to dependencies and introduces improvements to the mutation handling in the application. The most notable changes involve removing the `postcss` dependency and enhancing mutation caching with meta-based query invalidation.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32): Removed the `postcss` dependency (`8.5.6`).
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL63-L65): Removed the corresponding `postcss` lock entry.

### Mutation Handling Improvements:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-R15): Added a `MutationCache` to the `QueryClient` configuration, enabling meta-based query invalidation for mutations.
* [`src/lib/useBoard.ts`](diffhunk://#diff-5d5e4da6811effaa4ea76e552e0a1feb07bb378bf06e3cbae09816bd347cc7d1L18-R22): Replaced inline query invalidation in `useCreateColumn` with a `meta` property for cleaner and more reusable mutation handling.